### PR TITLE
fix: sync form state on onInput and onBlur for browser autofill

### DIFF
--- a/packages/form/src/FormBuilder.jsx
+++ b/packages/form/src/FormBuilder.jsx
@@ -1118,24 +1118,30 @@ export const FormBuilder = forwardRef(function FormBuilder(props, ref) {
 
   const handleFieldInput = useCallback(
     (name, value) => {
+      handleFieldChange(name, value);
       if (!validateOnChange) return;
       const err = validateField(name, value);
       updateErrors({ [name]: err });
     },
-    [validateOnChange, validateField, updateErrors]
+    [validateOnChange, validateField, updateErrors, handleFieldChange]
   );
 
   const handleFieldBlur = useCallback(
     (name, value) => {
-      if (!validateOnBlur) return;
       const resolvedValue = value != null ? value : formValuesRef.current[name];
+      // Sync value to form state if browser autofill populated the field without
+      // triggering onChange/onInput (e.g. browser autocomplete on non-first fields).
+      if (value != null && value !== formValuesRef.current[name]) {
+        handleFieldChange(name, value);
+      }
+      if (!validateOnBlur) return;
       const err = validateField(name, resolvedValue);
       updateErrors({ [name]: err });
       if (!err) {
         triggerAsyncValidation(name, resolvedValue);
       }
     },
-    [validateOnBlur, validateField, updateErrors, triggerAsyncValidation]
+    [validateOnBlur, validateField, updateErrors, triggerAsyncValidation, handleFieldChange]
   );
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
  ## Problem
  Browser autofill populates fields visually but doesn't reliably trigger
  `onChange` in HubSpot's UI Extensions environment. The 1.0.2 fix added
  `onInput` handlers, but `handleFieldInput` only ran validation — it never
  committed the value to form state. Result: required validation fails on
  submit even though the field looks filled in.

  ## Fix
  1. `handleFieldInput` — calls `handleFieldChange(name, value)` first, so
     paste and autofill update form state immediately.
  2. `handleFieldBlur` — syncs value to form state when the blur value differs
     from what's stored, catching any autofill that `onInput` missed.

  ## Tested
  - Browser autofill (all fields pass validation without needing to click into each field)
  - Manual paste (Ctrl+V)
  - Normal keyboard input (no regression)
