### PR TITLE
fix(form): fix AutoGrid responsive reflow broken by maxColumns chunking

### DIFF
--- a/packages/form/index.d.ts
+++ b/packages/form/index.d.ts
@@ -378,6 +378,7 @@ export interface FormBuilderProps {
   // Appearance / layout
   columns?: number;
   columnWidth?: number;
+  /** @deprecated No longer enforced — HubSpot AutoGrid requires all fields in one grid instance for responsive reflow. */
   maxColumns?: number;
   layout?: FormBuilderLayout;
   sections?: FormBuilderSection[];

--- a/packages/form/src/FormBuilder.jsx
+++ b/packages/form/src/FormBuilder.jsx
@@ -495,7 +495,7 @@ export const FormBuilder = forwardRef(function FormBuilder(props, ref) {
   const {
     columns = 1,                   // number of grid columns (1 = full-width stack)
     columnWidth,                   // AutoGrid columnWidth — responsive layout (overrides columns)
-    maxColumns,                    // cap number of columns per row in AutoGrid mode
+    maxColumns,                    // @deprecated — no longer enforced; AutoGrid reflow requires all fields in one grid instance
     layout,                        // explicit row layout array (overrides columns + columnWidth)
     sections,                      // FormBuilderSection[] — accordion field grouping
     gap = "sm",                    // gap between fields
@@ -2118,20 +2118,16 @@ export const FormBuilder = forwardRef(function FormBuilder(props, ref) {
 
     const flushBatch = () => {
       if (batch.length === 0) return;
-      // Chunk into rows of maxColumns when set
-      const chunks = maxColumns
-        ? Array.from({ length: Math.ceil(batch.length / maxColumns) }, (_, i) =>
-          batch.slice(i * maxColumns, i * maxColumns + maxColumns))
-        : [batch];
-      for (const chunk of chunks) {
-        elements.push(
-          <AutoGrid key={`ag-${chunk[0].name}`} columnWidth={columnWidth} flexible gap={gap}>
-            {chunk.map((f) => (
-              <React.Fragment key={f.name}>{renderField(f)}</React.Fragment>
-            ))}
-          </AutoGrid>
-        );
-      }
+      // All fields go in one AutoGrid so they can reflow together across column counts.
+      // Note: maxColumns cannot be enforced via separate AutoGrid instances — doing so
+      // breaks responsive reflow (fields in different AutoGrids can't flow into each other).
+      elements.push(
+        <AutoGrid key={`ag-${batch[0].name}`} columnWidth={columnWidth} flexible gap={gap}>
+          {batch.map((f) => (
+            <React.Fragment key={f.name}>{renderField(f)}</React.Fragment>
+          ))}
+        </AutoGrid>
+      );
       batch = [];
     };
 


### PR DESCRIPTION
## Summary

- Splitting fields into separate `AutoGrid` instances (to enforce `maxColumns`) prevented fields from reflowing across chunk boundaries when the panel narrowed — e.g. at 2 columns, Email was stranded alone instead of pairing with Phone
- All fields are now rendered in a single `AutoGrid` so HubSpot's native responsive reflow works correctly
- `maxColumns` is deprecated in both the source comment and `index.d.ts` — it cannot be enforced without breaking responsive behavior

## Test plan

- [ ] Open the Responsive AutoGrid demo with `columnWidth=200`
- [ ] Resize the panel to force 2-column layout
- [ ] Verify fields pair correctly: First Name + Last Name, Email + Phone, Company + Job Title
- [ ] Verify no orphaned fields on their own row

🤖 Generated with [Claude Code](https://claude.com/claude-code)