### PR TITLE
feat(utils): applyPatches — RFC 6902 JSON Patch subset (hs-uix/utils)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Requires `react` >= 18.0.0 and `@hubspot/ui-extensions` >= 0.14.0 as peer depend
 | **Calendar** | Presentational month/week/day/agenda calendar with search, filters, date navigation, event overlays, and experimental Gantt view | [Full documentation](https://github.com/05bmckay/hs-uix/blob/main/src/calendar/README.md) |
 | **Common Components** | Thin visual wrappers and shared collection primitives — `Icon`, `AutoTag`, `AutoStatusTag`, `AvatarStack`, `CrmLookupSelect`, `CollectionToolbar`, `CollectionFilterControl`, `CollectionSortSelect`, `CollectionCount`, and more | [Full documentation](https://github.com/05bmckay/hs-uix/blob/main/src/common-components/README.md) |
 | **CRM data** | `CrmDataTable` / `CrmKanban` — batch-fetching, client-side-paginating CRM table & board, plus the `useCrmSearch*` hooks behind them | [Full documentation](https://github.com/05bmckay/hs-uix/blob/main/src/utils/README.md) |
-| **Utils** | Pure helpers for formatting, options, HubSpot value guards, tag-variant inference, collection filtering/searching, and active-filter chips | [Full documentation](https://github.com/05bmckay/hs-uix/blob/main/src/utils/README.md) |
+| **Utils** | Pure helpers for formatting, options, HubSpot value guards, tag-variant inference, collection filtering/searching, active-filter chips, and RFC 6902 JSON Patch applying (`applyPatches`) | [Full documentation](https://github.com/05bmckay/hs-uix/blob/main/src/utils/README.md) |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ Low-risk, mostly-built code that closes real gaps. Ship as one "harvest" release
 | Component | Subpath | Stream | Source | Effort |
 |---|---|---|---|---|
 | **Safe wrappers** — hardened drop-ins that turn native silent-fails / throw-blanks-page into safe degrades: Icon alias-repair, EmptyState `imageName` fallback, StatisticsTrend `direction` aliasing, Popover compact-Tile padding, required-array coercion on collection props. | `hs-uix/safe` | 🅑 | `renderer/components.js` safety-net layer | S |
-| **`applyPatches`** — RFC-6902 JSON Patch subset (add/replace/remove/move/copy), permissive path-creation, structural sharing. Generic streaming-UI utility. | `hs-uix/utils` | 🅑 | `renderer/apply-patch.js` | XS |
+| ✅ **`applyPatches`** — RFC-6902 JSON Patch subset (add/replace/remove/move/copy), permissive path-creation, structural sharing. Generic streaming-UI utility. | `hs-uix/utils` | 🅑 | `renderer/apply-patch.js` | XS |
 
 > **Not building: Toaster.** The SDK's native [`actions.addAlert`](https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensions/ui-extensions-sdk/actions#display-alert-banners)
 > already renders host toast banners in every extension point (`settings`, `home`,

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ export {
   DEFAULT_SVG_FONT_WEIGHT,
 } from "./common-components";
 export {
+  applyPatches,
   buildActiveFilterChips,
   buildCrmSearchConfig,
   buildOptions,
@@ -89,6 +90,8 @@ export {
 export type {
   AutoTagOptions,
   AutoTagVariant,
+  JsonPatchOp,
+  JsonPatchOperation,
   AutoStatusTagOptions,
   AutoStatusTagVariant,
   StatusTagSortComparatorOptions,

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export {
   StyledText,
 } from "./common-components/index.js";
 export {
+  applyPatches,
   buildCrmSearchConfig,
   crmSearchResultToOption,
   buildOptions,

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -534,9 +534,10 @@ Behavior worth knowing:
 | Immutability | Returns a **new** document; untouched branches keep reference equality (structural sharing), so memoized renderers only re-render what changed. |
 | Permissive paths | Where RFC 6902 would error on a missing path prefix, `add`/`replace` create it — objects by default, arrays when the next segment is numeric or `-`. Built for patch streams where `/elements/x/props` can arrive before `/elements`. |
 | Root pointer | `path: ""` (or `"/"`) replaces the whole document. |
-| Array append | The standard `-` index appends (`{ op: "add", path: "/rows/-", value }`). |
+| Array `add` vs `replace` | Per RFC 6902, `add` at an existing index **inserts** (shifts the rest right); `replace` overwrites in place. The standard `-` index appends (`{ op: "add", path: "/rows/-", value }`). |
+| Array `remove` | An invalid or out-of-range index (`/rows/-`, `/rows/foo`, `/rows/99`) is a safe no-op — same spirit as removing a missing object key. |
 | Escaping | Standard RFC 6901 unescaping: `~1` → `/`, `~0` → `~`. |
-| `copy` | Deep-clones the source (JSON-safe values only — no `Date`/`Map`/`Set`). |
+| `copy` / `move` | `copy` deep-clones the source (JSON-safe values only — no `Date`/`Map`/`Set`). Pointers resolve own properties only, so `/constructor`-style segments read as missing instead of leaking functions into the document. |
 | Null doc | `applyPatches(null, patches)` starts from `{}`. Empty/missing `patches` returns the input as-is. |
 
 ---

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -12,6 +12,7 @@ Pure helper functions for formatting, mapping, guards, and lightweight data tran
 - `viewAdapters.js` — shape transforms between DataTable columns and Kanban cardFields (power a single "same data, different view" toggle)
 - `query.js` — shared collection query helpers: empty filter values, filter reset, active-filter chips, filtering, and search
 - `crmSearchAdapters.js` — CRM-bound data components (`CrmDataTable`, `CrmKanban`) plus the lower-level CRM search hooks and config builders behind them
+- `applyPatches.js` — RFC 6902 JSON Patch applier (add/replace/remove/move/copy) with structural sharing, built for streaming-UI flows
 
 ## Purpose
 
@@ -500,6 +501,43 @@ If you need to drive a custom view, the hooks and helpers are exported directly:
 - `crmSearchResultToOption` — map a single CRM record into an option.
 - `makeCrmSearchSelectField` / `makeCrmSearchMultiSelectField` — build FormBuilder field configs backed by CRM search.
 - `resolveCrmObjectType` — normalize object-type aliases (`"contact"` ↔ `"contacts"`, etc.).
+
+---
+
+## applyPatches.js
+
+RFC 6902 JSON Patch applier — the minimal subset that streaming UIs need.
+Supported ops: `add`, `replace`, `remove`, `move`, `copy`; anything else
+(including `test`) is skipped with a console warning.
+
+### `applyPatches(doc, patches)`
+
+```js
+import { applyPatches } from "hs-uix/utils";
+
+const doc = { meta: { title: "Dashboard" }, rows: [] };
+
+const next = applyPatches(doc, [
+  { op: "replace", path: "/meta/title", value: "Pipeline" },
+  { op: "add", path: "/rows/-", value: { id: "r1" } },
+]);
+// → { meta: { title: "Pipeline" }, rows: [{ id: "r1" }] }
+
+next === doc;          // → false (never mutates input)
+next.meta === doc.meta; // → false (changed branch)
+```
+
+Behavior worth knowing:
+
+| Behavior | Detail |
+|---|---|
+| Immutability | Returns a **new** document; untouched branches keep reference equality (structural sharing), so memoized renderers only re-render what changed. |
+| Permissive paths | Where RFC 6902 would error on a missing path prefix, `add`/`replace` create it — objects by default, arrays when the next segment is numeric or `-`. Built for patch streams where `/elements/x/props` can arrive before `/elements`. |
+| Root pointer | `path: ""` (or `"/"`) replaces the whole document. |
+| Array append | The standard `-` index appends (`{ op: "add", path: "/rows/-", value }`). |
+| Escaping | Standard RFC 6901 unescaping: `~1` → `/`, `~0` → `~`. |
+| `copy` | Deep-clones the source (JSON-safe values only — no `Date`/`Map`/`Set`). |
+| Null doc | `applyPatches(null, patches)` starts from `{}`. Empty/missing `patches` returns the input as-is. |
 
 ---
 

--- a/src/utils/applyPatches.js
+++ b/src/utils/applyPatches.js
@@ -1,0 +1,140 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// applyPatches — RFC 6902 JSON Patch applier, minimal subset.
+//
+// Supported ops: add, replace, remove, move, copy. Anything else (including
+// `test`) is skipped with a console warning.
+//
+// Returns a NEW document (structural sharing where safe). Never mutates the
+// input — callers can rely on reference equality to detect what changed,
+// which is what makes this useful for streaming UIs: feed each patch batch
+// through and re-render only what actually moved.
+//
+// Intentionally permissive where RFC 6902 is strict: if a path prefix is
+// missing, `add`/`replace` create it (objects by default, arrays when the
+// next segment looks like an index). That makes the applier robust for
+// streaming/partial-document flows where a patch for `/a/b` can arrive
+// before the patch that created `/a`.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * @param {any} doc  the document to patch (never mutated; `null`/`undefined`
+ *                   starts from `{}` when there are patches to apply)
+ * @param {Array<{op: string, path: string, from?: string, value?: any}>} patches
+ * @returns {any} a new document with every patch applied in order
+ */
+export function applyPatches(doc, patches) {
+  if (!patches || patches.length === 0) return doc;
+  let out = doc ?? {};
+  for (const op of patches) {
+    out = applyOne(out, op);
+  }
+  return out;
+}
+
+function applyOne(doc, op) {
+  const path = parsePointer(op.path);
+  switch (op.op) {
+    case "add":
+    case "replace":
+      return setAt(doc, path, op.value);
+    case "remove":
+      return removeAt(doc, path);
+    case "move": {
+      const from = parsePointer(op.from);
+      const value = getAt(doc, from);
+      const removed = removeAt(doc, from);
+      return setAt(removed, path, value);
+    }
+    case "copy": {
+      const from = parsePointer(op.from);
+      const value = getAt(doc, from);
+      return setAt(doc, path, deepClone(value));
+    }
+    default:
+      console.warn("[hs-uix] applyPatches: ignoring unsupported op:", op.op);
+      return doc;
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+function parsePointer(pointer) {
+  if (!pointer || pointer === "/") return [];
+  if (pointer[0] !== "/") {
+    throw new Error(`invalid JSON Pointer (must start with /): ${pointer}`);
+  }
+  // Split on "/", then unescape each segment.
+  return pointer
+    .slice(1)
+    .split("/")
+    .map((seg) => seg.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+function getAt(obj, segs) {
+  let cur = obj;
+  for (const seg of segs) {
+    if (cur == null) return undefined;
+    cur = Array.isArray(cur) ? cur[Number(seg)] : cur[seg];
+  }
+  return cur;
+}
+
+function setAt(obj, segs, value) {
+  if (segs.length === 0) return value;
+  const [head, ...rest] = segs;
+  const isArray = Array.isArray(obj);
+  if (isArray) {
+    const next = obj.slice();
+    const idx = head === "-" ? next.length : Number(head);
+    const existing = idx >= 0 && idx < next.length ? next[idx] : undefined;
+    const child = setAt(existing ?? {}, rest, value);
+    if (rest.length === 0) {
+      // Insert (for "-") vs replace.
+      if (head === "-") next.push(value);
+      else next[idx] = value;
+    } else {
+      next[idx] = child;
+    }
+    return next;
+  }
+  // Object
+  const base = obj && typeof obj === "object" ? obj : {};
+  if (rest.length === 0) {
+    return { ...base, [head]: value };
+  }
+  const existing = base[head];
+  const child = setAt(existing ?? (looksLikeArrayIndex(rest[0]) ? [] : {}), rest, value);
+  return { ...base, [head]: child };
+}
+
+function removeAt(obj, segs) {
+  if (segs.length === 0) return undefined;
+  const [head, ...rest] = segs;
+  if (Array.isArray(obj)) {
+    const next = obj.slice();
+    const idx = Number(head);
+    if (rest.length === 0) {
+      next.splice(idx, 1);
+    } else {
+      next[idx] = removeAt(next[idx], rest);
+    }
+    return next;
+  }
+  if (!obj || typeof obj !== "object") return obj;
+  if (rest.length === 0) {
+    const next = { ...obj };
+    delete next[head];
+    return next;
+  }
+  if (!(head in obj)) return obj;
+  return { ...obj, [head]: removeAt(obj[head], rest) };
+}
+
+function looksLikeArrayIndex(seg) {
+  return seg === "-" || /^\d+$/.test(seg);
+}
+
+function deepClone(v) {
+  // Fine for JSON-shaped documents — no Date/Map/Set etc.
+  return v === undefined ? undefined : JSON.parse(JSON.stringify(v));
+}

--- a/src/utils/applyPatches.js
+++ b/src/utils/applyPatches.js
@@ -13,7 +13,8 @@
 // missing, `add`/`replace` create it (objects by default, arrays when the
 // next segment looks like an index). That makes the applier robust for
 // streaming/partial-document flows where a patch for `/a/b` can arrive
-// before the patch that created `/a`.
+// before the patch that created `/a`. Invalid array indices on `remove` are
+// a safe no-op (same spirit as removing a missing object key).
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
@@ -35,20 +36,22 @@ function applyOne(doc, op) {
   const path = parsePointer(op.path);
   switch (op.op) {
     case "add":
+      return setAt(doc, path, op.value, true);
     case "replace":
-      return setAt(doc, path, op.value);
+      return setAt(doc, path, op.value, false);
     case "remove":
       return removeAt(doc, path);
     case "move": {
+      // RFC 6902: move = remove from `from`, then ADD at `path`.
       const from = parsePointer(op.from);
       const value = getAt(doc, from);
       const removed = removeAt(doc, from);
-      return setAt(removed, path, value);
+      return setAt(removed, path, value, true);
     }
     case "copy": {
       const from = parsePointer(op.from);
       const value = getAt(doc, from);
-      return setAt(doc, path, deepClone(value));
+      return setAt(doc, path, deepClone(value), true);
     }
     default:
       console.warn("[hs-uix] applyPatches: ignoring unsupported op:", op.op);
@@ -74,27 +77,45 @@ function getAt(obj, segs) {
   let cur = obj;
   for (const seg of segs) {
     if (cur == null) return undefined;
-    cur = Array.isArray(cur) ? cur[Number(seg)] : cur[seg];
+    if (Array.isArray(cur)) {
+      cur = cur[Number(seg)];
+    } else if (typeof cur === "object") {
+      // Own properties only — JSON documents have no inherited keys, and
+      // resolving "/constructor" etc. through the prototype chain would leak
+      // non-JSON values (functions) into the document via move/copy.
+      cur = Object.prototype.hasOwnProperty.call(cur, seg) ? cur[seg] : undefined;
+    } else {
+      return undefined;
+    }
   }
   return cur;
 }
 
-function setAt(obj, segs, value) {
+// `insert` = RFC `add` semantics: at an existing array index, splice the value
+// in (shifting the rest right) instead of overwriting. `replace` overwrites.
+function setAt(obj, segs, value, insert) {
   if (segs.length === 0) return value;
   const [head, ...rest] = segs;
-  const isArray = Array.isArray(obj);
-  if (isArray) {
+  if (Array.isArray(obj)) {
     const next = obj.slice();
     const idx = head === "-" ? next.length : Number(head);
-    const existing = idx >= 0 && idx < next.length ? next[idx] : undefined;
-    const child = setAt(existing ?? {}, rest, value);
     if (rest.length === 0) {
-      // Insert (for "-") vs replace.
-      if (head === "-") next.push(value);
-      else next[idx] = value;
-    } else {
-      next[idx] = child;
+      if (head === "-") {
+        next.push(value);
+      } else if (insert && Number.isInteger(idx) && idx >= 0 && idx <= next.length) {
+        next.splice(idx, 0, value);
+      } else {
+        next[idx] = value;
+      }
+      return next;
     }
+    const existing = idx >= 0 && idx < next.length ? next[idx] : undefined;
+    next[idx] = setAt(
+      existing ?? (looksLikeArrayIndex(rest[0]) ? [] : {}),
+      rest,
+      value,
+      insert
+    );
     return next;
   }
   // Object
@@ -103,7 +124,12 @@ function setAt(obj, segs, value) {
     return { ...base, [head]: value };
   }
   const existing = base[head];
-  const child = setAt(existing ?? (looksLikeArrayIndex(rest[0]) ? [] : {}), rest, value);
+  const child = setAt(
+    existing ?? (looksLikeArrayIndex(rest[0]) ? [] : {}),
+    rest,
+    value,
+    insert
+  );
   return { ...base, [head]: child };
 }
 
@@ -111,8 +137,12 @@ function removeAt(obj, segs) {
   if (segs.length === 0) return undefined;
   const [head, ...rest] = segs;
   if (Array.isArray(obj)) {
-    const next = obj.slice();
     const idx = Number(head);
+    // Invalid or out-of-range index → safe no-op. (Without the guard,
+    // Number("-")/Number("foo") are NaN and splice(NaN, 1) silently deletes
+    // index 0.)
+    if (!Number.isInteger(idx) || idx < 0 || idx >= obj.length) return obj;
+    const next = obj.slice();
     if (rest.length === 0) {
       next.splice(idx, 1);
     } else {
@@ -135,6 +165,8 @@ function looksLikeArrayIndex(seg) {
 }
 
 function deepClone(v) {
-  // Fine for JSON-shaped documents — no Date/Map/Set etc.
-  return v === undefined ? undefined : JSON.parse(JSON.stringify(v));
+  // Fine for JSON-shaped documents — no Date/Map/Set etc. Non-JSON values
+  // (functions, undefined) clone to undefined instead of crashing the batch.
+  const json = v === undefined ? undefined : JSON.stringify(v);
+  return json === undefined ? undefined : JSON.parse(json);
 }

--- a/src/utils/applyPatches.test.js
+++ b/src/utils/applyPatches.test.js
@@ -63,12 +63,27 @@ describe("applyPatches", () => {
     expect(out).toEqual({ list: ["A", "b"] });
   });
 
+  it("add at an existing array index INSERTS (RFC 6902), replace overwrites", () => {
+    const doc = { l: ["a", "b", "c"] };
+    expect(applyPatches(doc, [{ op: "add", path: "/l/1", value: "X" }]))
+      .toEqual({ l: ["a", "X", "b", "c"] });
+    expect(applyPatches(doc, [{ op: "replace", path: "/l/1", value: "X" }]))
+      .toEqual({ l: ["a", "X", "c"] });
+  });
+
   it("moves values between paths", () => {
     const out = applyPatches(
       { draft: { title: "T" }, published: {} },
       [{ op: "move", from: "/draft/title", path: "/published/title" }]
     );
     expect(out).toEqual({ draft: {}, published: { title: "T" } });
+  });
+
+  it("moves within an array without losing elements", () => {
+    const out = applyPatches({ l: ["a", "b", "c"] }, [
+      { op: "move", from: "/l/0", path: "/l/1" },
+    ]);
+    expect(out).toEqual({ l: ["b", "a", "c"] });
   });
 
   it("copies values without sharing references", () => {
@@ -124,5 +139,21 @@ describe("applyPatches", () => {
     const doc = { a: { b: 1 } };
     const out = applyPatches(doc, [{ op: "remove", path: "/a/missing/deep" }]);
     expect(out).toEqual({ a: { b: 1 } });
+  });
+
+  it("removing an invalid or out-of-range array index is a safe no-op", () => {
+    const doc = { l: ["a", "b", "c"] };
+    expect(applyPatches(doc, [{ op: "remove", path: "/l/-" }])).toEqual(doc);
+    expect(applyPatches(doc, [{ op: "remove", path: "/l/foo" }])).toEqual(doc);
+    expect(applyPatches(doc, [{ op: "remove", path: "/l/99" }])).toEqual(doc);
+    expect(applyPatches(doc, [{ op: "remove", path: "/l/-1" }])).toEqual(doc);
+  });
+
+  it("does not resolve pointers through the prototype chain or crash on non-JSON values", () => {
+    const doc = { a: 1 };
+    const out = applyPatches(doc, [{ op: "copy", from: "/constructor", path: "/b" }]);
+    expect(out.b).toBeUndefined();
+    const moved = applyPatches(doc, [{ op: "move", from: "/toString", path: "/c" }]);
+    expect(moved.c).toBeUndefined();
   });
 });

--- a/src/utils/applyPatches.test.js
+++ b/src/utils/applyPatches.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { applyPatches } from "./applyPatches.js";
+
+describe("applyPatches", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the input untouched for empty or missing patches", () => {
+    const doc = { a: 1 };
+    expect(applyPatches(doc, [])).toBe(doc);
+    expect(applyPatches(doc, null)).toBe(doc);
+    expect(applyPatches(doc, undefined)).toBe(doc);
+    expect(applyPatches(null, [])).toBe(null);
+  });
+
+  it("adds and replaces values at nested paths", () => {
+    const doc = { meta: { title: "old" } };
+    const out = applyPatches(doc, [
+      { op: "replace", path: "/meta/title", value: "new" },
+      { op: "add", path: "/meta/subtitle", value: "sub" },
+    ]);
+    expect(out).toEqual({ meta: { title: "new", subtitle: "sub" } });
+  });
+
+  it("starts from {} when the document is null and patches exist", () => {
+    expect(applyPatches(null, [{ op: "add", path: "/a", value: 1 }])).toEqual({ a: 1 });
+    expect(applyPatches(undefined, [{ op: "add", path: "/a", value: 1 }])).toEqual({ a: 1 });
+  });
+
+  it("replaces the whole document for the root pointer", () => {
+    expect(applyPatches({ a: 1 }, [{ op: "replace", path: "", value: { b: 2 } }])).toEqual({ b: 2 });
+    expect(applyPatches({ a: 1 }, [{ op: "add", path: "/", value: 42 }])).toBe(42);
+  });
+
+  it("creates missing path prefixes permissively (objects by default, arrays for numeric segments)", () => {
+    const out = applyPatches({}, [{ op: "add", path: "/elements/hero/props/title", value: "Hi" }]);
+    expect(out).toEqual({ elements: { hero: { props: { title: "Hi" } } } });
+
+    const withArray = applyPatches({}, [{ op: "add", path: "/rows/0/name", value: "first" }]);
+    expect(withArray).toEqual({ rows: [{ name: "first" }] });
+
+    const dashArray = applyPatches({}, [{ op: "add", path: "/rows/-", value: "x" }]);
+    expect(dashArray).toEqual({ rows: ["x"] });
+  });
+
+  it("removes object keys and array items", () => {
+    const out = applyPatches(
+      { a: 1, b: 2, list: ["x", "y", "z"] },
+      [
+        { op: "remove", path: "/a" },
+        { op: "remove", path: "/list/1" },
+      ]
+    );
+    expect(out).toEqual({ b: 2, list: ["x", "z"] });
+  });
+
+  it("appends with the '-' array pointer and replaces by index", () => {
+    const out = applyPatches({ list: ["a"] }, [
+      { op: "add", path: "/list/-", value: "b" },
+      { op: "replace", path: "/list/0", value: "A" },
+    ]);
+    expect(out).toEqual({ list: ["A", "b"] });
+  });
+
+  it("moves values between paths", () => {
+    const out = applyPatches(
+      { draft: { title: "T" }, published: {} },
+      [{ op: "move", from: "/draft/title", path: "/published/title" }]
+    );
+    expect(out).toEqual({ draft: {}, published: { title: "T" } });
+  });
+
+  it("copies values without sharing references", () => {
+    const out = applyPatches(
+      { source: { nested: { n: 1 } } },
+      [{ op: "copy", from: "/source/nested", path: "/dest" }]
+    );
+    expect(out.dest).toEqual({ n: 1 });
+    expect(out.dest).not.toBe(out.source.nested);
+  });
+
+  it("unescapes ~1 (/) and ~0 (~) in pointer segments", () => {
+    const out = applyPatches({}, [
+      { op: "add", path: "/a~1b", value: "slash" },
+      { op: "add", path: "/c~0d", value: "tilde" },
+    ]);
+    expect(out).toEqual({ "a/b": "slash", "c~d": "tilde" });
+  });
+
+  it("never mutates the input and shares untouched branches", () => {
+    const doc = { keep: { deep: [1, 2] }, change: { v: "old" } };
+    const out = applyPatches(doc, [{ op: "replace", path: "/change/v", value: "new" }]);
+    expect(doc).toEqual({ keep: { deep: [1, 2] }, change: { v: "old" } });
+    expect(out).not.toBe(doc);
+    expect(out.change).not.toBe(doc.change);
+    expect(out.keep).toBe(doc.keep); // structural sharing
+  });
+
+  it("applies patches in order", () => {
+    const out = applyPatches({}, [
+      { op: "add", path: "/v", value: 1 },
+      { op: "replace", path: "/v", value: 2 },
+      { op: "add", path: "/list", value: [] },
+      { op: "add", path: "/list/-", value: "a" },
+      { op: "add", path: "/list/-", value: "b" },
+    ]);
+    expect(out).toEqual({ v: 2, list: ["a", "b"] });
+  });
+
+  it("skips unsupported ops (including test) with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const doc = { a: 1 };
+    const out = applyPatches(doc, [{ op: "test", path: "/a", value: 1 }]);
+    expect(out).toBe(doc);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on a pointer that does not start with /", () => {
+    expect(() => applyPatches({}, [{ op: "add", path: "a/b", value: 1 }])).toThrow(/JSON Pointer/);
+  });
+
+  it("removing a missing path is a safe no-op on objects", () => {
+    const doc = { a: { b: 1 } };
+    const out = applyPatches(doc, [{ op: "remove", path: "/a/missing/deep" }]);
+    expect(out).toEqual({ a: { b: 1 } });
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
+export * from "./applyPatches.js";
 export * from "./collections.js";
 export * from "./crmSearchAdapters.js";
 export * from "./formatters.js";

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -247,6 +247,23 @@ export interface DerivedCardField<Row = Record<string, unknown>> {
   href?: (row: Row) => string | { url: string; external?: boolean };
 }
 
+export type JsonPatchOp = "add" | "replace" | "remove" | "move" | "copy" | "test";
+
+export interface JsonPatchOperation {
+  /** Supported: add / replace / remove / move / copy. Others (incl. `test`) are skipped with a warning. */
+  op: JsonPatchOp;
+  /** JSON Pointer (RFC 6901), e.g. "/elements/hero/props/title". "" or "/" addresses the document root. */
+  path: string;
+  /** Source pointer for "move" / "copy". */
+  from?: string;
+  value?: unknown;
+}
+
+export declare function applyPatches<Doc = unknown>(
+  doc: Doc | null | undefined,
+  patches: ReadonlyArray<JsonPatchOperation> | null | undefined
+): Doc;
+
 export declare function formatCurrency(value: unknown, options?: FormatCurrencyOptions): string;
 export declare function formatCurrencyCompact(value: unknown, options?: FormatCurrencyCompactOptions): string;
 export declare function formatDate(value: unknown, options?: FormatDateOptions): string;


### PR DESCRIPTION
## Summary

Phase 1 roadmap harvest: ports `renderer/apply-patch.js` from hs-uix-studio into `hs-uix/utils` as a generic streaming-UI utility.

- **`applyPatches(doc, patches)`** — RFC 6902 subset (`add` / `replace` / `remove` / `move` / `copy`; anything else, including `test`, skips with a one-time warn)
- Immutable with **structural sharing** — untouched branches keep reference equality, so memoized renderers only re-render what changed
- **Permissive path creation** for streaming flows (`/a/b` can arrive before `/a`); objects by default, arrays when the next segment is numeric or `-`
- Hand-written types (`JsonPatchOp`, `JsonPatchOperation`), README section, exported from `hs-uix/utils` + the root barrel

## Hardening beyond the Studio source

A multi-agent adversarial review of the port caught three latent bugs the Studio renderer never hit (it only patched object-keyed maps):

- `add` at an existing array index now **inserts** per RFC 6902 §4.1 instead of overwriting (and in-array `move` no longer destroys the displaced element)
- `remove` with an invalid array index (`/l/-`, `/l/foo`, `/l/-1`) is a safe no-op — previously `splice(NaN, 1)` silently deleted index 0
- Pointers resolve **own properties only** and `deepClone` guards non-JSON values, so `copy from "/constructor"` reads as missing instead of crashing the batch

## Test plan

- 19 vitest cases: every op, RFC 6901 escaping, `-` append, insert-vs-overwrite, structural sharing/no-mutation, permissive prefixes, root replacement, invalid-index no-ops, prototype-chain guards
- `npm test` (113 passed) and `npm run build` + CJS dist smoke test

Merge note: trivially conflicts with #2 in `src/index.js`/`ROADMAP.md` (adjacent additive lines) — merge either first, rebase the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)